### PR TITLE
Fix shopping list allergen dedup, food group fallback, and Svelte list keys

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9219,22 +9219,6 @@
         }
       }
     },
-    "node_modules/yaml": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
-      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
-      "extraneous": true,
-      "license": "ISC",
-      "bin": {
-        "yaml": "bin.mjs"
-      },
-      "engines": {
-        "node": ">= 14.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/eemeli"
-      }
-    },
     "node_modules/yaml-ast-parser": {
       "version": "0.0.43",
       "resolved": "https://registry.npmjs.org/yaml-ast-parser/-/yaml-ast-parser-0.0.43.tgz",

--- a/src/lib/server/shopping-list.ts
+++ b/src/lib/server/shopping-list.ts
@@ -217,7 +217,14 @@ function buildAllergenAlerts(
 		}
 	}
 
-	return alerts;
+	// Deduplicate: keep one alert per member per reason
+	const seen = new Set<string>();
+	return alerts.filter((alert) => {
+		const key = `${alert.memberName}::${alert.reason}`;
+		if (seen.has(key)) return false;
+		seen.add(key);
+		return true;
+	});
 }
 
 function groupIntoCategories(
@@ -226,7 +233,7 @@ function groupIntoCategories(
 	const groups = new Map<string, ShoppingListItem[]>();
 
 	for (const item of items) {
-		const group = item.foodGroup ?? 'other';
+		const group = item.foodGroup && CATEGORY_CONFIG[item.foodGroup] ? item.foodGroup : 'other';
 		const existing = groups.get(group);
 		if (existing) {
 			existing.push(item);

--- a/src/routes/shopping/+page.svelte
+++ b/src/routes/shopping/+page.svelte
@@ -219,7 +219,7 @@
                     <!-- Item list -->
                     {#if !isCollapsed}
                         <ul class="divide-y divide-slate-50 px-5 pb-3">
-                            {#each items as item (item.ingredient)}
+                            {#each items as item (`${item.ingredient}::${item.unit ?? ''}`)}
                                 <li class="flex items-start gap-3 py-3">
                                     <!-- Checkbox -->
                                     <button
@@ -252,7 +252,7 @@
                                                 {formatQuantity(item.totalAmount, item.unit)}
                                             </span>
                                         {/if}
-                                        {#each item.allergenAlerts as alert (`${alert.memberName}-${alert.reason}`)}
+                                        {#each item.allergenAlerts as alert, i (`${alert.memberName}-${alert.reason}-${i}`)}
                                             <span
                                                 class="inline-flex items-center rounded-full border px-1.5 py-0.5 text-xs font-medium {alertColour(alert)}"
                                                 title={alertTooltip(alert)}
@@ -298,7 +298,7 @@
                             Clear all
                         </button>
                         <ul class="divide-y divide-slate-50">
-                            {#each allCheckedItems as item (item.ingredient)}
+                            {#each allCheckedItems as item (`${item.ingredient}::${item.unit ?? ''}`)}
                                 <li class="flex items-start gap-3 py-3 opacity-50">
                                     <!-- Checked checkbox -->
                                     <button


### PR DESCRIPTION
## Changes

- **Deduplicate allergen alerts**: Alerts are now deduplicated by member+reason so each member's concern appears only once per item.
- **Food group fallback**: Items with a food group not present in CATEGORY_CONFIG now correctly fall back to the 'other' category instead of creating a missing group.
- **Svelte list keys**: Shopping list items now use ingredient::unit as the key (instead of ingredient alone) to prevent duplicate key errors when the same ingredient appears with different units. Allergen alert keys include an index as an additional guard.